### PR TITLE
fix: Fix the value property array and spelling errors in the Flights spec

### DIFF
--- a/flight-data/flights/openapi.yaml
+++ b/flight-data/flights/openapi.yaml
@@ -1,4 +1,3 @@
----
 # OpenAPI Spec for the KongAir Flights service
 openapi: 3.0.0
 
@@ -61,7 +60,7 @@ paths:
             format: date
       responses:
         '200':
-          description: Successful respone with scheduled flights
+          description: Successful response with scheduled flights
           headers:
            hostname:
              description: "The hostname of the machine fulfilling the request."
@@ -74,22 +73,21 @@ paths:
                 items:
                   $ref: '#/components/schemas/Flight'
               examples:
-                Example Flights List:
-                  value: |
-                   [
-                      {
+                ExampleFlightsList:
+                  summary: A list of scheduled flights
+                  value: 
+                    - {
                         "number": "KD924",
                         "route_id": "LHR-SFO",
                         "scheduled_departure": "2024-03-20T09:12:28Z",
                         "scheduled_arrival": "2024-03-20T19:12:28Z"
-                      },
-                      {
+                      }
+                    - {
                         "number": "KD925",
                         "route_id": "SFO-LHR",
                         "scheduled_departure": "2024-03-21T09:12:28Z",
                         "scheduled_arrival": "2024-03-21T19:12:28Z"
                       }
-                   ]
 
   "/flights/{flightNumber}":
     get:
@@ -120,8 +118,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Flight'
               examples:
-                Example Flight KD924:
-                  value: |
+                ExampleFlightKD924:
+                  value: 
                     {
                       "number": "KD924",
                       "route_id": "LHR-SFO",
@@ -211,5 +209,5 @@ components:
       required:
         - flight_number
         - in_flight_entertainment
-        - mean_options
+        - meal_options
         - aircraft_type


### PR DESCRIPTION
I was trying to run this spec in Insomnia and was getting a `"value" property type must be an array` error, so I used ChatGPT to fix it. This revision doesn't have any warning level errors when I run it in Insomnia, but the formatting also might not be 100% correct since AI helped fix it. 

There were also a few spelling errors that this fixes.